### PR TITLE
Update leader-manager.config

### DIFF
--- a/leader-manager.config
+++ b/leader-manager.config
@@ -4,7 +4,7 @@ files:
         owner: root
         group: root
         content: |
-            * * * * * ec2-user gem install aws-sdk-v1 --no-ri --no-rdoc
+            * * * * * ec2-user gem install nokogiri -v '~> 1.5.0' --no-ri --no-rdoc && gem install aws-sdk-v1 --no-ri --no-rdoc
         encoding: plain
 
     "/etc/cron.d/check_for_aws":


### PR DESCRIPTION
This fixes the script on the latest Elastic Beanstalk PHP environment. Nokogiri requires a newer Ruby version than what is already on the instances. So this forces gem to install Nokogiri version 1.5.0. Tested on Elastic Beanstalk and currently using this in a production environment.